### PR TITLE
fix: add early bird section

### DIFF
--- a/docs/css/common.css
+++ b/docs/css/common.css
@@ -464,6 +464,23 @@ a:is(.active) {
   text-decoration-color: var(--text-color);
 }
 
+.recap-email-link {
+  display: inline-flex;
+  color: var(--brand-color);
+}
+
+.recap-email-link:is(:hover) {
+  color: var(--brand-color-alt);
+  text-decoration-color: var(--brand-color-alt);
+}
+
+.recap-email-link:is(:focus, .active, .active:hover) {
+  outline: none;
+  color: var(--brand-color-alt);
+  text-decoration: underline;
+  text-decoration-color: var(--brand-color-alt);
+}
+
 .recap-btn {
   display: inline-block;
   padding-block: 1.125rem;

--- a/docs/index.html
+++ b/docs/index.html
@@ -178,14 +178,19 @@
         </table>
 
         <h3>Interested in sponsoring?</h3>
-        <p>We offer discounted bundled sponsorship packages and are excited to collaborate with you in creating a customized package that meets your organization's specific requirements.</p>
+        <p>Are you interested in sponsoring not only re>≡CAP but also one or all of our CodeConnect (UI5con, ABAPconf Europe) partners? We offer discounted bundled sponsorship packages and are excited to collaborate with you in creating a customized package that meets your organization's specific requirements</p>
         <br/>
 
-        <a href="recap.conf@gmail.com?subject=[reCAP 2024] Sponsoring" class="recap-btn">
+        <a href="mailto:recap.conf@gmail.com?subject=[reCAP 2024] Sponsoring" class="recap-btn">
           contact us
         </a>
-
-        <!-- THEY MENTIONED SOMETHING ABOUT EARLY BIRD TICKETS -->
+    </section>
+    <section>
+      <div class="recap-wrap">
+        <h2>Early Bird Tickets</h2>
+        <p>You have a long journey and need to plan your trip to re>≡CAP 2024 early (before the official registration starts)? Please send us an <a href="mailto:recap.conf@gmail.com?subject=[reCAP 2024] Early Bird Tickets" target="_blank" rel="noopener noreferrer" title="contact us via mail" class="recap-email-link">email</a> with your name, company, country and the information for which conference you want to register in addition to re>≡CAP 2024 (UI5con, ABAPconf Europe).</p>
+       
+       
     </section>
   </main>
 


### PR DESCRIPTION
Added the information requested by Sebastian in his email:
- _The “Contact Us” button does not seem to work for me._ **(fixed)**
- _Do we want to add this statement below the sponsor packages table?
“Are you interested in sponsoring not only re>≡CAP but also one or all of our CodeConnect (UI5con, ABAPconf Europe) partners? We offer discounted bundled sponsorship packages and are excited to collaborate with you in creating a customized package that meets your organization's specific requirements.”_  **(done)**
- _Can we add one big headline “Early Bird Tickets”
“You have a long journey and need to plan your trip to re>≡CAP 2024 early (before the official registration starts)? Please send us an [email](mailto:recap.conf@gmail.com) with your name, company, country and the information for which conference you want to register in addition to re>≡CAP 2024 (UI5con, ABAPconf Europe).”_  **(done)**